### PR TITLE
Handle ill-formatted command string caused by direct conversion of TokenStream to String

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sailfish-minify"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Abrudan Paul - Andrei <paulandreiabrudan@proton.me>"]
 description = "Hacky but simple minification support for sailfish, using html-minifier by default"
 homepage = "https://github.com/pauldotsh/sailfish-minify"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ struct MinifyOptions {
 }
 
 fn run_custom_command_unchecked_wrapper(command: &str, input: &Path, output: &Path) -> Output {
-    let mut cmd: Vec<&str> = command.split(' ').collect();
+    let mut cmd: Vec<&str> = command.split([' ', '\n']).collect();
     cmd.extend(vec![
         input.to_str().unwrap(),
         "-o",


### PR DESCRIPTION
The documentation for `impl Display for TokenStream` (https://doc.rust-lang.org/beta/proc_macro/struct.TokenStream.html#impl-Display-for-TokenStream), advises against converting `TokenStream` directly to `String` using the `Display` trait, because the exact output is unreliable. In particular, the conversion process may introduce an indeterminate amount of whitespace. From my experience, the following macro invocation introduces a newline character before the last flag.

```#[min_with(Custom(minhtml --keep-closing-tags --minify-js --minify-css --preserve-chevron-percent-template-syntax))]```

The above macro produces the following command:

```minhtml --keep-closing-tags --minify-js --minify-css\n--preserve-chevron-percent-template-syntax```

This obviously results in a compilation error. So, this PR defends against that error by accounting for newline characters when splitting the command string.